### PR TITLE
ver 4.0.0: change CLI

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # Curious Goran
 
-- Request data from Jira based on particular filter ID
+- Request data from Jira based on JQL
 - Create a CSV file with time statistics (in days or hours) on every ticket and count how many times ticket switched from one status to another.
 
-## Request data by filterID
-1. Run `npm start <Jira filterId>` (example: `npm start 666`)
+## Request data
 
-
-## Request data by JQL
 1. Add your JQLs to the `/data/jql.json` file (check the example in the `/data/jql.example.json` file)
-2. Run `npm start jql`
+2. Run `npm start`
 3. Curious Goran will create a separate CSV file for each entry in the `/data/jql.json` file.
-For example from this `/data/jql.json` Curious Goran will make two files --> `Bob Torn.csv` and `Super heroes team.csv`. In both of them there will be a result of request.
+   For example from this `/data/jql.json` Curious Goran will make two files --> `Bob Torn.csv` and `Super heroes team.csv`. In both of them there will be a result of request.
+
 ```
 {
     [
@@ -19,7 +17,8 @@ For example from this `/data/jql.json` Curious Goran will make two files --> `Bo
         {"Super heroes team": "project%3D\"Super%20%26%20Heroes\""}
     ]
 }
-``` 
+```
+
 ---
 
 ## Setup
@@ -37,7 +36,9 @@ For example from this `/data/jql.json` Curious Goran will make two files --> `Bo
 4. Add base URL to `.env` file as `JIRA_BASE_URL` (check `.env.example` file)
 
 ### CSV build config
-*Curious Goran will add "url" and "title" to resulted CSV. So you shouldn't use these fields in the csv-build-convig.json*
+
+_Curious Goran will add "url" and "title" to resulted CSV. So you shouldn't use these fields in the csv-build-convig.json_
+
 1. Check `/data/csv-build-config.example.json` file.
 2. Add your own statuses to the csv in the order you would like.
 3. Rename `csv-build-config.example.json` to `csv-build-config.json`

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,76 +4,60 @@ import { config } from "./config";
 import { createTickets } from "./convert";
 import { get } from "./get";
 import { buildCsv } from "./make-csv";
-import { CsvBuildConfig, CsvPresentation, JiraTicket, Work } from "./types";
-const jqls = require('../data/jql.json') as Work;
+import {
+  CsvBuildConfig,
+  CsvPresentation,
+  JiraTicket,
+  JqlConfig,
+  Work,
+} from "./types";
+const jqls = require("../data/jql.json");
 
-
-const searchForWork = (): Work => {
-    const JQL_ARGUMENT = 'jql';
-
-    const [cliArg] = process.argv.slice(2);
-
-    if (!cliArg) {
-        throw new Error(
-            "You have to use an argument.\nEither filterId or a jql.\nRead more about it in the README.md file"
-        );
-    }
-
-    if (cliArg === JQL_ARGUMENT) {
-        return jqls.map(({ fileName, url }) => {
-            return {
-                fileName,
-                url: `/search?expand=changelog&jql=${url}`
-            }
-        })
-    }
-
-    const isArgAFilterId = !isNaN(Number(cliArg))
-    if (isArgAFilterId) {
-        return [{
-            fileName: 'result',
-            url: `/search?expand=changelog&jql=filter=${cliArg}`
-        }]
-    }
-
-    throw new Error(
-        "Sorry, this tool won't work without filter ID or jql.\nPlease, check the README.md file for reference"
-    );
-}
-
+const searchForWork = (jqlConfig: JqlConfig): Work => {
+  return jqlConfig.map(({ fileName, url }) => {
+    return {
+      fileName,
+      url: `/search?expand=changelog&jql=${url}`,
+    };
+  });
+};
 
 const run = async () => {
-    console.log("Curious Goran starting to work...");
+  console.log("Curious Goran starting to work...");
 
-    const workList = searchForWork();
-    const streams = workList.map(({ fileName }) => {
-        return createWriteStream(`./data/${fileName}.csv`);
-    })
-    const csvPresentations: CsvPresentation = [];
+  const workList = searchForWork(jqls);
+  const streams = workList.map(({ fileName }) => {
+    return createWriteStream(`./data/${fileName}.csv`);
+  });
+  const csvPresentations: CsvPresentation = [];
 
-    for (const { fileName, url } of workList) {
-        console.log(`Start working regarding ${fileName}.csv\nUsing this path ${url}`);
-        const jiraTickets: JiraTicket[] = await get(url);
-        const tickets = createTickets(jiraTickets);
+  for (const { fileName, url } of workList) {
+    console.log(
+      `Start working regarding ${fileName}.csv\nUsing this path ${url}`
+    );
+    const jiraTickets: JiraTicket[] = await get(url);
+    const tickets = createTickets(jiraTickets);
 
-        console.log("Start converting Jira issues to CSV...");
-        const csvTemplate = require("../data/csv-build-config.json") as CsvBuildConfig;
-        csvPresentations.push(buildCsv(tickets, csvTemplate, config));
-    }
+    console.log("Start converting Jira issues to CSV...");
+    const csvTemplate =
+      require("../data/csv-build-config.json") as CsvBuildConfig;
+    csvPresentations.push(buildCsv(tickets, csvTemplate, config));
+  }
 
-    console.log('Writing to files...');
-    streams.forEach((stream, index) => {
-        stream.write(csvPresentations[index], () => {
-            stream.close();
-        })
+  console.log("Writing to files...");
+  streams.forEach((stream, index) => {
+    stream.write(csvPresentations[index], () => {
+      stream.close();
     });
-}
+  });
+};
 
-run().then(() => {
-    console.log('Done!');
+run()
+  .then(() => {
+    console.log("Done!");
     exit(0);
-}).catch((error) => {
+  })
+  .catch((error) => {
     console.log(error);
     exit(1);
-});
-
+  });

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,4 +64,6 @@ export interface JiraTicket {
   };
 }
 
+export type JqlConfig = {fileName: string, url: string,}[]
+
 export type Work = { fileName: string; url: string }[]


### PR DESCRIPTION
From this release user won't be able to use `npm start %filterId%` or `npm start jql` CLI commands. From now on only `npm start` available and user has to configure a launch using JQL config.